### PR TITLE
Fix Ranger Mini V2 spin command mapping

### DIFF
--- a/include/ugv_sdk/details/robot_base/ranger_base.hpp
+++ b/include/ugv_sdk/details/robot_base/ranger_base.hpp
@@ -1,6 +1,7 @@
 #ifndef RANGER_BASE_HPP
  #define RANGER_BASE_HPP
  
+ #include <cmath>
  #include <cstdint>
  #include <mutex>
  #include <string>
@@ -102,6 +103,19 @@
  
  using RangerMiniV3Base = RangerBase;
  class RangerMiniV2Base : public RangerBase {
+  public:
+   void SetMotionCommand(double linear_vel, double steer_angle,
+                         double angular_vel) override {
+     if (std::abs(angular_vel) > 1e-6) {
+       constexpr double kSpinRadius = 0.3068110167513546;
+       AgilexBase<ProtocolV2Parser>::SendMotionCommand(
+           linear_vel, 0.0, angular_vel * kSpinRadius, steer_angle);
+       return;
+     }
+ 
+     RangerBase::SetMotionCommand(linear_vel, steer_angle, angular_vel);
+   }
+ 
    RangerCommonSensorState GetCommonSensorState() override {
      auto common_sensor =
          AgilexBase<ProtocolV2Parser>::GetCommonSensorStateMsgGroup();


### PR DESCRIPTION
**Summary**
Fixes #8  Ranger Mini V2 turn-in-place commands by adding a Mini V2-specific `SetMotionCommand()` override.

**What Changed**
- Maps nonzero `angular_vel` to the protocol V2 spin-speed field via `lateral_velocity`.
- Converts body angular velocity to wheel linear speed using the Mini V2 spin radius.
- Leaves normal zero-yaw Ranger command behavior unchanged.

**Why**
Ranger Mini V2 expects spin speed in CAN `0x111` bytes `4-5`. The generic Ranger path placed ROS yaw velocity in bytes `2-3`, causing the robot to enter spin geometry without rotating the drive wheels.